### PR TITLE
make zulip config optional, and other small setup improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DATABASE_URL='postgresql://...'
 DJANGO_SECRET_KEY='...........'
 
 # leave as is
-ALLOWED_HOSTS='localhost,rctv-dev.recurse.com'
+ALLOWED_HOSTS='localhost,rctv-dev.recurse.com,127.0.0.1'
 DJANGO_SETTINGS_MODULE='rctv.settings.dev'
 CSRF_TRUSTED_ORIGINS='http://localhost,https://rctv-dev.recurse.com,http://127.0.0.1'
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ create a new postgres database for rctv
 ```bash
 # macOS (adapt for your OS)
 initdb -A trust /usr/local/var/postgres
-# Connect to default DB
-psql -U $USER -d -d postgres
+
+# or with docker
+docker run --rm --name pg -ePOSTGRES_PASSWORD=a -d --network=host postgres
+
+# Then connect to default DB. One of these should work:
+psql -U postgres -d postgres
+psql -U postgres -d postgres -h localhost -p 5432
 ```
 
 ```sql
@@ -40,7 +45,7 @@ define an `.env` file. Copy from `.env.example` and fill in the values inside `"
 cp .env.example .env
 ```
 
-[create a Zulip
+(optional) [create a Zulip
 Bot](https://zulip.com/api/deploying-bots#running-a-bot-using-the-zulip-botserver)
 (choose Outgoing Webhook Bot), [download its `zuliprc` file](https://zulip.com/api/api-keys), 
 and move it to the root of this repository + rename it to `.zuliprc` (with a dot at the beginning)
@@ -49,9 +54,10 @@ and move it to the root of this repository + rename it to `.zuliprc` (with a dot
 cp ~/Downloads/zuliprc .zuliprc
 ```
 
-also! create a django super user for yourself!
+Initialize the database and create a django super user for yourself!
 
 ```bash
+python manage.py migrate
 python manage.py createsuperuser
 # answer admin (username), a@a.ca, admin (password) and 'y' to confirm the bad password
 ```

--- a/core/utils/zulip_api.py
+++ b/core/utils/zulip_api.py
@@ -1,19 +1,22 @@
 from pathlib import Path
 
-import zulip
 from django.conf import settings
 
 APPROVED_STREAMS = ["RCTV", "blogging", "random", "cute"]
 
 # config values will be fetched from the ZULIP_* environment variables
-client = zulip.Client()
-
+if settings.ZULIP_INCOMING_WEBHOOK_TOKEN:
+    import zulip
+    client = zulip.Client()
+else:
+    client = None
 
 # zulip api at large:
 # https://zulip.com/api/
 # api doc re: creating a 'narrow' i.e. searching
 # https://zulip.com/api/construct-narrow
 def get_last_ten_messages_from_stream(stream_name, sender=None):
+    assert client, "Missing Zulip config"
     assert stream_name in APPROVED_STREAMS
     request_narrow_payload = [
         {"operator": "stream", "operand": stream_name},


### PR DESCRIPTION
I managed to get this far in the local setup!

<img width="928" height="996" alt="image" src="https://github.com/user-attachments/assets/54713dc5-62e7-4073-b622-5457da1d4222" />

i still get directed to the real recurse auth flow at /developers. not sure if there's a way to disable that locally so i can hack on parts of the system where auth is not relevant.

ultimately, i'm hacking towards a "show immediately" button, or something similar.